### PR TITLE
Add support for UUID variants 1, 3, 4 and 5 (for Varnish 3)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,9 @@ import uuid;
 DESCRIPTION
 ===========
 
-UUID Varnish vmod used to generate a uuid.
+UUID Varnish vmod used to generate a uuid, including versions 1, 3, 4
+and 5 as specified in RFC 4122. See the RFC for details about the
+various versions.
 
 
 FUNCTIONS
@@ -35,12 +37,98 @@ Prototype
 Return value
 	STRING
 Description
-	Returns a uuid
+	Returns a uuid version 1 (based on MAC address and the current time)
 UUID
         ::
 
                 set req.http.X-Flow-ID = "cache-" + uuid.uuid();
 
+uuid_v1
+-------
+
+Prototype
+        ::
+
+                uuid_v1()
+Return value
+	STRING
+Description
+	Returns a uuid version 1. The functions `uuid()` and `uuid_v1()`
+        are aliases for one another.
+Example
+        ::
+
+                set req.http.X-Flow-ID = "cache-" + uuid.uuid_v1();
+
+uuid_v3
+-------
+
+Prototype
+        ::
+
+                uuid_v3(STRING namespace, STRING name)
+Return value
+	STRING
+Description
+	Returns a uuid version 3, based on an MD5 hash formed from
+        `namespace` and `name`. The `namespace` argument MUST be
+        one of the following:
+
+* "nil" (for the "nil UUID")
+* "ns:DNS" (for the domain name system)
+* "ns:URL" (for the URL namespace)
+* "ns:OID" (for the ISO object identifier namespace)
+* "ns:X500" (for X.500 distinguished names)
+* a valid 36-character representation of a UUID, i.e. a string of the form "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", where all of the x's are hex digits, with appropriate restrictions on UUID formats (cf. the RFC)
+
+If these conditions are not met, then `uuid_v3()` fails; it returns
+a null string (typically, the header specified in VCL will not be set),
+and an error message is emitted to the Varnish log with the tag
+`VCL_error`.
+
+The `name` argument can be any string.
+
+Example
+        ::
+
+              set req.http.X-DNS-ID = uuid.uuid_v3("ns:DNS", "www.widgets.com");
+              set req.http.X-MyNS-ID = uuid.uuid_v3("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com");
+
+uuid_v4
+-------
+
+Prototype
+        ::
+
+                uuid_v4()
+Return value
+	STRING
+Description
+	Returns a uuid version 4, based on random numbers.
+Example
+        ::
+
+                set req.http.X-Rand-ID = uuid.uuid_v4();
+
+uuid_v5
+-------
+
+Prototype
+        ::
+
+                uuid_v5(STRING namespace, STRING name)
+Return value
+	STRING
+Description
+	Returns a uuid version 5, based on a SHA1 hash formed from
+        `namespace` and `name`. The same restrictions and failure
+        conditions regarding the `namespace` argument hold as for
+        `uuid_v3()` above. The `name` argument can be any string.
+Example
+        ::
+
+              set req.http.X-DNS-ID = uuid.uuid_v5("ns:DNS", "www.widgets.com");
+              set req.http.X-MyNS-ID = uuid.uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com");
 
 DEPENDENCIES
 ============

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,89 @@ if test "x$VMODDIR" = x; then
 	fi
 fi
 
+# This corresponds to FreeBSD's WARNS level 6
+DEVELOPER_CFLAGS="-Wall -Wstrict-prototypes \
+-Wmissing-prototypes \
+-Wpointer-arith \
+-Wreturn-type \
+-Wcast-qual \
+-Wwrite-strings \
+-Wswitch \
+-Wshadow \
+-Wcast-align \
+-Wunused-parameter \
+-Wchar-subscripts \
+-Winline \
+-Wnested-externs \
+-Wredundant-decls -Wformat"
+
+# Additional flags for GCC 4
+EXTRA_DEVELOPER_CFLAGS="-Wextra \
+-Wno-missing-field-initializers \
+-Wno-sign-compare"
+
+# --enable-developer-warnings
+AC_ARG_ENABLE(developer-warnings,
+	AS_HELP_STRING([--enable-developer-warnings],
+		       [enable strict warnings (default is NO)]),
+	CFLAGS="${CFLAGS} ${DEVELOPER_CFLAGS}")
+
+# --enable-debugging-symbols
+AC_ARG_ENABLE(debugging-symbols,
+	AS_HELP_STRING([--enable-debugging-symbols],
+		       [enable debugging symbols (default is NO)]),
+	CFLAGS="${CFLAGS} -O0 -g -fno-inline")
+
+# --enable-diagnostics
+AC_ARG_ENABLE(diagnostics,
+	AS_HELP_STRING([--enable-diagnostics],
+		       [enable run-time diagnostics (default is NO)]),
+	CFLAGS="${CFLAGS} -DDIAGNOSTICS")
+
+# --enable-extra-developer-warnings
+AC_ARG_ENABLE(extra-developer-warnings,
+	AS_HELP_STRING([--enable-extra-developer-warnings],
+		       [enable even stricter warnings (default is NO)]),
+	[],
+	[enable_extra_developer_warnings=no])
+
+if test "x$enable_stack_protector" != "xno"; then
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="${CFLAGS} ${EXTRA_DEVELOPER_CFLAGS}"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM([],[],[])],
+		[],
+		[AC_MSG_WARN([All of ${EXTRA_DEVELOPER_CFLAGS} not supported, disabling])
+		    CFLAGS="$save_CFLAGS"])
+fi
+
+# --enable-stack-protector
+AC_ARG_ENABLE(stack-protector,
+	AS_HELP_STRING([--enable-stack-protector],
+		       [enable stack protector (default is NO)]),
+	[],
+	[enable_stack_protector=no])
+
+if test "x$enable_stack_protector" != "xno"; then
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="${CFLAGS} -fstack-protector-all"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM([],[],[])],
+		[],
+		[AC_MSG_WARN([-fstack-protector not supported, disabling])
+		    CFLAGS="$save_CFLAGS"])
+fi
+
+# --enable-tests
+AC_ARG_ENABLE(tests,
+	AS_HELP_STRING([--enable-tests],[build test programs (default is NO)]))
+AM_CONDITIONAL([ENABLE_TESTS], [test x$enable_tests = xyes])
+
+# --enable-werror
+AC_ARG_ENABLE(werror,
+	AS_HELP_STRING([--enable-werror],[use -Werror (default is NO)]),
+	CFLAGS="${CFLAGS} -Werror")
+
 AC_CONFIG_FILES([
 	Makefile
 	src/Makefile

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,0 +1,112 @@
+varnishtest "Test the various uuid versions"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+   import uuid from "${vmod_topbuild}/src/.libs/libvmod_uuid.so";
+
+   sub vcl_deliver {
+      if (uuid.uuid() ~
+          "^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$") {
+         set resp.http.uuid = "OK";
+      }
+
+      if (uuid.uuid_v1() ~
+          "^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v1 = "OK";
+      }
+
+      # Known v3 value from RFC 4122 Errata ID 1352      
+      if (uuid.uuid_v3("ns:DNS", "www.widgets.com") ==
+          "3d813cbb-47fb-32ba-91df-831e1593ac29") {
+         set resp.http.uuid_v3_dns_widgets = "OK";
+      }
+      if (uuid.uuid_v3("nil", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_nil_widgets = "OK";
+      }
+      if (uuid.uuid_v3("ns:URL", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_url_widgets = "OK";
+      }
+      if (uuid.uuid_v3("ns:OID", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_oid_widgets = "OK";
+      }
+      if (uuid.uuid_v3("ns:X500", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_x500_widgets = "OK";
+      }
+      if (uuid.uuid_v3("379b0b72-fcde-4276-96ff-94fe3066326a",
+                       "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_uuid_widgets = "OK";
+      }
+      if (uuid.uuid_v3("illegal", "www.widgets.com")) {
+         set resp.http.uuid_v3_illegal_ns = "NotOK";
+      }
+
+      if (uuid.uuid_v4() ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v4 = "OK";
+      }
+
+      # Known v5 value from ruby gem UUIDTools test data
+      if (uuid.uuid_v5("ns:DNS", "www.widgets.com") ==
+          "21f7f8de-8051-5b89-8680-0195ef798b6a") {
+         set resp.http.uuid_v5_dns_widgets = "OK";
+      }
+      if (uuid.uuid_v5("nil", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_nil_widgets = "OK";
+      }
+      if (uuid.uuid_v5("ns:URL", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_url_widgets = "OK";
+      }
+      if (uuid.uuid_v5("ns:OID", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_oid_widgets = "OK";
+      }
+      if (uuid.uuid_v5("ns:X500", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_x500_widgets = "OK";
+      }
+      if (uuid.uuid_v5("379b0b72-fcde-4276-96ff-94fe3066326a",
+                       "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_uuid_widgets = "OK";
+      }
+      if (uuid.uuid_v5("illegal", "www.widgets.com")) {
+         set resp.http.uuid_v5_illegal_ns = "NotOK";
+      }
+   }
+} -start
+
+client c1 {
+   txreq -url "/"
+   rxresp
+   expect resp.http.uuid == "OK"
+   expect resp.http.uuid_v1 == "OK"
+   expect resp.http.uuid_v3_dns_widgets == "OK"
+   expect resp.http.uuid_v3_nil_widgets == "OK"
+   expect resp.http.uuid_v3_url_widgets == "OK"
+   expect resp.http.uuid_v3_oid_widgets == "OK"
+   expect resp.http.uuid_v3_x500_widgets == "OK"
+   expect resp.http.uuid_v3_uuid_widgets == "OK"
+   expect resp.http.uuid_v3_illegal_ns == <undef>
+   expect resp.http.uuid_v4 == "OK"
+   expect resp.http.uuid_v5_dns_widgets == "OK"
+   expect resp.http.uuid_v5_nil_widgets == "OK"
+   expect resp.http.uuid_v5_url_widgets == "OK"
+   expect resp.http.uuid_v5_oid_widgets == "OK"
+   expect resp.http.uuid_v5_x500_widgets == "OK"
+   expect resp.http.uuid_v5_uuid_widgets == "OK"
+   expect resp.http.uuid_v5_illegal_ns == <undef>
+}
+
+client c1 -run
+

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -104,8 +104,9 @@ _uuid(struct sess *sp, int utype, ...) {
    if (uuid_str == NULL)
       return(NULL);
 
+   assert(strlen(uuid_str) == UUID_LEN_STR);
    u = WS_Reserve(sp->wrk->ws, 0);     // Reserve some work space 
-   if (sizeof(uuid_str) > u) {
+   if (u < UUID_LEN_STR + 1) {
       // No space, reset and leave 
       WS_Release(sp->wrk->ws, 0);
       return(NULL);
@@ -114,15 +115,13 @@ _uuid(struct sess *sp, int utype, ...) {
    p = sp->wrk->ws->f;                 // Front of workspace area 
 
    strcpy(p, uuid_str);
-   // keep track of how much we actually used
-   v += strlen(uuid_str);
    // free up the uuid string once it's copied in place
    if(uuid_str){
       free(uuid_str);
    }
 
    // Update work space with what we've used 
-   WS_Release(sp->wrk->ws, v);
+   WS_Release(sp->wrk->ws, UUID_LEN_STR + 1);
    if (DEBUG)
       debug("uuid: %s", p);
    return(p);

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -58,8 +58,8 @@ debug(const char *fmt, ...){
      }                                                                  \
    } while(0)
    
-static char *
-uuid(struct sess *sp, int utype, va_list ap) {
+static inline char *
+mkuuid(struct sess *sp, int utype, va_list ap) {
     uuid_t *uuid = NULL, *uuid_ns;
     uuid_rc_t rc;
     char *str = NULL, *ns, *name;
@@ -91,7 +91,7 @@ uuid(struct sess *sp, int utype, va_list ap) {
 static const char *
 _uuid(struct sess *sp, int utype, ...) {
    char *p;
-   unsigned u, v;
+   unsigned u;
    va_list ap;
 
    CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
@@ -99,7 +99,7 @@ _uuid(struct sess *sp, int utype, ...) {
           || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
 
    va_start(ap, utype);
-   char *uuid_str = uuid(sp, utype, ap);
+   char *uuid_str = mkuuid(sp, utype, ap);
    va_end(ap);
    if (uuid_str == NULL)
       return(NULL);

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -45,27 +45,28 @@ debug(const char *fmt, ...){
    va_end(ap);
 }
 
-#define UUID_CALL(RC,SP,CALL,UUID,STR)                                  \
+#define UUID_CALL(RC,SP,CALL,UUID,UUIDNS)                               \
    do {                                                                 \
      if (((RC) = (CALL)) != UUID_RC_OK) {                               \
         WSP((SP), SLT_VCL_error, "vmod uuid error %d: %s", (RC),        \
             uuid_error(RC));                                            \
         if ((UUID) != NULL)                                             \
            uuid_destroy(UUID);                                          \
-        if ((STR) != NULL)                                              \
-           free(STR);                                                   \
-        return(NULL);                                                   \
+        if ((UUIDNS) != NULL)                                           \
+           uuid_destroy(UUIDNS);                                        \
+        return(-1);                                                     \
      }                                                                  \
    } while(0)
    
-static inline char *
-mkuuid(struct sess *sp, int utype, va_list ap) {
-    uuid_t *uuid = NULL, *uuid_ns;
+static inline int
+mkuuid(struct sess *sp, int utype, const char *str, va_list ap) {
+    uuid_t *uuid = NULL, *uuid_ns = NULL;
     uuid_rc_t rc;
-    char *str = NULL, *ns, *name;
+    char *ns, *name;
+    size_t len = UUID_LEN_STR + 1;
 
     if (utype == UUID_MAKE_V3 || utype == UUID_MAKE_V5) {
-       UUID_CALL(rc, sp, uuid_create(&uuid_ns), uuid, str);
+       UUID_CALL(rc, sp, uuid_create(&uuid_ns), uuid, uuid_ns);
        ns = (char *) va_arg(ap, char *);
        AN(ns);
        name = (char *) va_arg(ap, char *);
@@ -73,52 +74,53 @@ mkuuid(struct sess *sp, int utype, va_list ap) {
        if (uuid_load(uuid_ns, ns) != UUID_RC_OK
            && uuid_import(uuid_ns, UUID_FMT_STR, (const void *) ns, strlen(ns))
               != UUID_RC_OK) {
-          UUID_CALL(rc, sp, uuid_destroy(uuid_ns), uuid, str);
-          return(NULL);
+          UUID_CALL(rc, sp, uuid_destroy(uuid_ns), uuid, uuid_ns);
+          return(-1);
        }
+       AN(uuid_ns);
     }
 
-    UUID_CALL(rc, sp, uuid_create(&uuid), uuid, str);
-    UUID_CALL(rc, sp, uuid_make(uuid, utype, uuid_ns, name), uuid, str);
-    str = NULL;
-    UUID_CALL(rc, sp, uuid_export(uuid, UUID_FMT_STR, &str, NULL), uuid, str);
-    UUID_CALL(rc, sp, uuid_destroy(uuid), uuid, str);
+    UUID_CALL(rc, sp, uuid_create(&uuid), uuid, uuid_ns);
+    UUID_CALL(rc, sp, uuid_make(uuid, utype, uuid_ns, name), uuid, uuid_ns);
+    UUID_CALL(rc, sp, uuid_export(uuid, UUID_FMT_STR, &str, &len), uuid,
+              uuid_ns);
+    assert(len == UUID_LEN_STR + 1);
+    UUID_CALL(rc, sp, uuid_destroy(uuid), uuid, uuid_ns);
+    if (uuid_ns != NULL)
+       uuid_destroy(uuid_ns);
     if (DEBUG)
        debug("uuid: %s", str);
-    return(str);
+    return(0);
 }
 
-static const char *
+static inline const char *
 _uuid(struct sess *sp, int utype, ...) {
-   char *p;
+   char *p, uuid_str[UUID_LEN_STR + 1];
    unsigned u;
    va_list ap;
+   int ret;
 
    CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
    assert(utype == UUID_MAKE_V1 || utype == UUID_MAKE_V3
           || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
 
    va_start(ap, utype);
-   char *uuid_str = mkuuid(sp, utype, ap);
+   ret = mkuuid(sp, utype, uuid_str, ap);
    va_end(ap);
-   if (uuid_str == NULL)
+   if (ret != 0)
       return(NULL);
 
    assert(strlen(uuid_str) == UUID_LEN_STR);
    u = WS_Reserve(sp->wrk->ws, 0);     // Reserve some work space 
    if (u < UUID_LEN_STR + 1) {
-      // No space, reset and leave 
+      // No space, reset and leave
+      WSP(sp, SLT_VCL_error, "vmod uuid error: insufficient workspace");
       WS_Release(sp->wrk->ws, 0);
       return(NULL);
    }
 
    p = sp->wrk->ws->f;                 // Front of workspace area 
-
    strcpy(p, uuid_str);
-   // free up the uuid string once it's copied in place
-   if(uuid_str){
-      free(uuid_str);
-   }
 
    // Update work space with what we've used 
    WS_Release(sp->wrk->ws, UUID_LEN_STR + 1);

--- a/src/vmod_uuid.vcc
+++ b/src/vmod_uuid.vcc
@@ -1,2 +1,6 @@
 Module uuid
-Function STRING uuid(PRIV_CALL)
+Function STRING uuid()
+Function STRING uuid_v1()
+Function STRING uuid_v3(STRING, STRING)
+Function STRING uuid_v4()
+Function STRING uuid_v5(STRING, STRING)


### PR DESCRIPTION
This adds support for all of the UUID variants supported by the OSSP library (OSSP does not support variant 2). Most users will probably be interested in variant 4 (the fully random version).

We've had the VMOD running successfully in production since the end of November 2013.