### PR TITLE
Support UUID variants 1, 3, 4 and 5, and Varnish 4

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil . ((indent-tabs-mode . t)))
+ (c-mode . ((c-file-style . "BSD"))))
+

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,9 @@ import uuid;
 DESCRIPTION
 ===========
 
-UUID Varnish vmod used to generate a uuid.
+UUID Varnish vmod used to generate a uuid, including versions 1, 3, 4
+and 5 as specified in RFC 4122. See the RFC for details about the
+various versions.
 
 
 FUNCTIONS
@@ -35,12 +37,98 @@ Prototype
 Return value
 	STRING
 Description
-	Returns a uuid
+	Returns a uuid version 1 (based on MAC address and the current time)
 UUID
         ::
 
                 set req.http.X-Flow-ID = "cache-" + uuid.uuid();
 
+uuid_v1
+-------
+
+Prototype
+        ::
+
+                uuid_v1()
+Return value
+	STRING
+Description
+	Returns a uuid version 1. The functions `uuid()` and `uuid_v1()`
+        are aliases for one another.
+Example
+        ::
+
+                set req.http.X-Flow-ID = "cache-" + uuid.uuid_v1();
+
+uuid_v3
+-------
+
+Prototype
+        ::
+
+                uuid_v3(STRING namespace, STRING name)
+Return value
+	STRING
+Description
+	Returns a uuid version 3, based on an MD5 hash formed from
+        `namespace` and `name`. The `namespace` argument MUST be
+        one of the following:
+
+* "nil" (for the "nil UUID")
+* "ns:DNS" (for the domain name system)
+* "ns:URL" (for the URL namespace)
+* "ns:OID" (for the ISO object identifier namespace)
+* "ns:X500" (for X.500 distinguished names)
+* a valid 36-character representation of a UUID, i.e. a string of the form "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", where all of the x's are hex digits, with appropriate restrictions on UUID formats (cf. the RFC)
+
+If these conditions are not met, then `uuid_v3()` fails; it returns
+a null string (typically, the header specified in VCL will not be set),
+and an error message is emitted to the Varnish log with the tag
+`VCL_error`.
+
+The `name` argument can be any string.
+
+Example
+        ::
+
+              set req.http.X-DNS-ID = uuid.uuid_v3("ns:DNS", "www.widgets.com");
+              set req.http.X-MyNS-ID = uuid.uuid_v3("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com");
+
+uuid_v4
+-------
+
+Prototype
+        ::
+
+                uuid_v4()
+Return value
+	STRING
+Description
+	Returns a uuid version 4, based on random numbers.
+Example
+        ::
+
+                set req.http.X-Rand-ID = uuid.uuid_v4();
+
+uuid_v5
+-------
+
+Prototype
+        ::
+
+                uuid_v5(STRING namespace, STRING name)
+Return value
+	STRING
+Description
+	Returns a uuid version 5, based on a SHA1 hash formed from
+        `namespace` and `name`. The same restrictions and failure
+        conditions regarding the `namespace` argument hold as for
+        `uuid_v3()` above. The `name` argument can be any string.
+Example
+        ::
+
+              set req.http.X-DNS-ID = uuid.uuid_v5("ns:DNS", "www.widgets.com");
+              set req.http.X-MyNS-ID = uuid.uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com");
 
 DEPENDENCIES
 ============

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ vmod_uuid
 Varnish UUID Module
 ----------------------
 
-:Author: Mitchell Broome
-:Date: 2013-08-01
+:Author: Mitchell Broome, Geoff Simmons
+:Date: 2014-12-11
 :Version: 1.0
 :Manual section: 3
 
@@ -135,7 +135,7 @@ DEPENDENCIES
 
 Libvmod-uuid requires the OSSP uuid library to generate uuids.  It
 is available at http://www.ossp.org/pkg/lib/uuid/ or possibly as a
-prepackaged library from your linux distribution.  i
+prepackaged library from your linux distribution.
 
 In the case of Redhat/Fedora/CentOS, the rpm is named uuid.  Ensure
 you install the rpms with the following command::
@@ -146,30 +146,21 @@ you install the rpms with the following command::
 INSTALLATION
 ============
 
-This is a basic implementation to generate a uuid for use in varnish.
+The installation process is standard for a Varnish 4 VMOD -- build the
+VMOD on a system where an instance of Varnish 4 is installed, and the
+auto-tools will attempt to locate the Varnish instance, and then pull
+in libraries and other support files from there.
 
-The source tree is based on autotools to configure the building, and
-does also have the necessary bits in place to do functional unit tests
-using the varnishtest tool.
+Quick start
+-----------
 
-Usage::
+This sequence should be enough in typical setups:
 
- ./autogen.sh
- ./configure VARNISHSRC=DIR [VMODDIR=DIR]
-
-`VARNISHSRC` is the directory of the Varnish source tree for which to
-compile your vmod. Both the `VARNISHSRC` and `VARNISHSRC/include`
-will be added to the include search paths for your module.
-
-Optionally you can also set the vmod install directory by adding
-`VMODDIR=DIR` (defaults to the pkg-config discovered directory from your
-Varnish installation).
-
-Make targets:
-
-* make - builds the vmod
-* make install - installs your vmod in `VMODDIR`
-* make check - runs the unit tests in ``src/tests/*.vtc``
+1. ``./autogen.sh``  (for git-installation)
+2. ``./configure``
+3. ``make``
+4. ``make check`` (regression tests)
+5. ``make install`` (may require root: sudo make install)
 
 In your VCL you could then use this vmod along the following lines::
         
@@ -180,6 +171,53 @@ In your VCL you could then use this vmod along the following lines::
                 set req.http.X-Flow-ID = "cache-" + uuid.uuid();
         }
 
+Alternative configs
+-------------------
+
+As with Varnish itself, you can set additional flags and macros in the
+``configure`` step, and/or define environment variables to affect the
+build config.
+
+For example, if you are building the VMOD against a Varnish instance
+with a non-standard installation prefix, then set these env variables
+before running ``configure``:
+
+* PREFIX=/path/to/varnish/install/prefix
+* export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+* export ACLOCAL_PATH=$PREFIX/share/aclocal
+* export PATH=$PREFIX/bin:$PREFIX/sbin:$PATH
+
+``configure`` must locate the ``varnishtest`` and ``varnishd``
+binaries so that ``make check`` can be run. Usually it should be able
+to find them, but if necessary you can set the variables
+``VARNISHTEST`` and/or ``VARNISHD`` with the full paths.
+
+For developers
+--------------
+
+As with Varnish, you can use these ``configure`` options for stricter
+compiling:
+
+* ``--enable-developer-warnings``
+* ``--enable-extra-developer-warnings`` (for GCC 4)
+* ``--enable-werror``
+
+The VMOD must always build successfully with these options enabled.
+
+Also as with Varnish, you can add ``--enable-debugging-symbols``, so
+that the VMOD's symbols are available to debuggers, in core dumps and
+so forth.
+
+HISTORY
+=======
+
+* Version 1.0: Varnish 4 version, supporting all UUID variants
+  by Geoffrey Simmons <geoff@uplex.de>, UPLEX Nils Goroll Systemoptimierung
+  for Otto GmbH & KG
+  https://github.com/otto-de/libvmod-uuid
+
+* Version 0.1: Initial Varnish 3 version, by Mitchell Broome of Sharecare
+  https://github.com/Sharecare/libvmod-uuid
 
 COPYRIGHT
 =========

--- a/autogen.sh
+++ b/autogen.sh
@@ -11,6 +11,9 @@ Darwin)
 FreeBSD)
 	LIBTOOLIZE=libtoolize
 	;;
+OpenBSD)
+	LIBTOOLIZE=libtoolize
+	;;
 Linux)
 	LIBTOOLIZE=libtoolize
 	;;

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,89 @@ if test "x$VMODDIR" = x; then
 	fi
 fi
 
+# This corresponds to FreeBSD's WARNS level 6
+DEVELOPER_CFLAGS="-Wall -Wstrict-prototypes \
+-Wmissing-prototypes \
+-Wpointer-arith \
+-Wreturn-type \
+-Wcast-qual \
+-Wwrite-strings \
+-Wswitch \
+-Wshadow \
+-Wcast-align \
+-Wunused-parameter \
+-Wchar-subscripts \
+-Winline \
+-Wnested-externs \
+-Wredundant-decls -Wformat"
+
+# Additional flags for GCC 4
+EXTRA_DEVELOPER_CFLAGS="-Wextra \
+-Wno-missing-field-initializers \
+-Wno-sign-compare"
+
+# --enable-developer-warnings
+AC_ARG_ENABLE(developer-warnings,
+	AS_HELP_STRING([--enable-developer-warnings],
+		       [enable strict warnings (default is NO)]),
+	CFLAGS="${CFLAGS} ${DEVELOPER_CFLAGS}")
+
+# --enable-debugging-symbols
+AC_ARG_ENABLE(debugging-symbols,
+	AS_HELP_STRING([--enable-debugging-symbols],
+		       [enable debugging symbols (default is NO)]),
+	CFLAGS="${CFLAGS} -O0 -g -fno-inline")
+
+# --enable-diagnostics
+AC_ARG_ENABLE(diagnostics,
+	AS_HELP_STRING([--enable-diagnostics],
+		       [enable run-time diagnostics (default is NO)]),
+	CFLAGS="${CFLAGS} -DDIAGNOSTICS")
+
+# --enable-extra-developer-warnings
+AC_ARG_ENABLE(extra-developer-warnings,
+	AS_HELP_STRING([--enable-extra-developer-warnings],
+		       [enable even stricter warnings (default is NO)]),
+	[],
+	[enable_extra_developer_warnings=no])
+
+if test "x$enable_stack_protector" != "xno"; then
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="${CFLAGS} ${EXTRA_DEVELOPER_CFLAGS}"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM([],[],[])],
+		[],
+		[AC_MSG_WARN([All of ${EXTRA_DEVELOPER_CFLAGS} not supported, disabling])
+		    CFLAGS="$save_CFLAGS"])
+fi
+
+# --enable-stack-protector
+AC_ARG_ENABLE(stack-protector,
+	AS_HELP_STRING([--enable-stack-protector],
+		       [enable stack protector (default is NO)]),
+	[],
+	[enable_stack_protector=no])
+
+if test "x$enable_stack_protector" != "xno"; then
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="${CFLAGS} -fstack-protector-all"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM([],[],[])],
+		[],
+		[AC_MSG_WARN([-fstack-protector not supported, disabling])
+		    CFLAGS="$save_CFLAGS"])
+fi
+
+# --enable-tests
+AC_ARG_ENABLE(tests,
+	AS_HELP_STRING([--enable-tests],[build test programs (default is NO)]))
+AM_CONDITIONAL([ENABLE_TESTS], [test x$enable_tests = xyes])
+
+# --enable-werror
+AC_ARG_ENABLE(werror,
+	AS_HELP_STRING([--enable-werror],[use -Werror (default is NO)]),
+	CFLAGS="${CFLAGS} -Werror")
+
 AC_CONFIG_FILES([
 	Makefile
 	src/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.59)
-AC_COPYRIGHT([Copyright (c) 2011 Varnish Software AS])
-AC_INIT([libvmod-uuid], [trunk])
+AC_COPYRIGHT([Copyright (c) 2013 Sharecare, Inc.])
+AC_INIT([libvmod-uuid], [1.0])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR(src/vmod_uuid.vcc)
 AM_CONFIG_HEADER(config.h)
@@ -36,35 +36,32 @@ PKG_PROG_PKG_CONFIG
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([sys/stdlib.h])
+AC_CHECK_HEADERS([stdio.h])
+AC_CHECK_HEADERS([string.h])
+AC_CHECK_HEADERS([stdlib.h])
+AC_CHECK_HEADERS([uuid.h])
+AC_CHECK_HEADERS([stdarg.h])
+AC_CHECK_HEADERS([syslog.h])
 
 # Check for python
 AC_CHECK_PROGS(PYTHON, [python3 python3.1 python3.2 python2.7 python2.6 python2.5 python2 python], [AC_MSG_ERROR([Python is needed to build this vmod, please install python.])])
 
-# Varnish source tree
-AC_ARG_VAR([VARNISHSRC], [path to Varnish source tree (mandatory)])
-if test "x$VARNISHSRC" = x; then
-	AC_MSG_ERROR([No Varnish source tree specified])
+# Varnish include files tree
+VARNISH_VMOD_INCLUDES
+VARNISH_VMOD_DIR
+VARNISH_VMODTOOL
+
+# Check paths to varnishd and varnishtest
+AC_ARG_VAR([VARNISHTEST], [path to varnishtest (mandatory for make check)])
+AC_ARG_VAR([VARNISHD], [path to varnishd (mandatory for make check)])
+AC_PATH_PROG([VARNISHTEST], [varnishtest])
+AC_PATH_PROG([VARNISHD], [varnishd], [/bin/false],
+             [${PATH}${PATH_SEPARATOR}/usr/local/sbin${PATH_SEPARATOR}/usr/sbin])
+if test "x$VARNISHD" = x; then
+   AC_MSG_FAILURE([Can't locate varnishd])
 fi
-VARNISHSRC=`cd $VARNISHSRC && pwd`
-AC_CHECK_FILE([$VARNISHSRC/include/varnishapi.h],
-	[],
-	[AC_MSG_FAILURE(["$VARNISHSRC" is not a Varnish source directory])]
-)
-
-# Check that varnishtest is built in the varnish source directory
-AC_CHECK_FILE([$VARNISHSRC/bin/varnishtest/varnishtest],
-	[],
-	[AC_MSG_FAILURE([Can't find "$VARNISHSRC/bin/varnishtest/varnishtest". Please build your varnish source directory])]
-)
-
-# vmod installation dir
-AC_ARG_VAR([VMODDIR], [vmod installation directory @<:@LIBDIR/varnish/vmods@:>@])
-if test "x$VMODDIR" = x; then
-	VMODDIR=`pkg-config --variable=vmoddir varnishapi`
-	if test "x$VMODDIR" = x; then
-		AC_MSG_FAILURE([Can't determine vmod installation directory])
-	fi
+if test "x$VARNISHTEST" = x; then
+   AC_MSG_FAILURE([Can't locate varnishtest])
 fi
 
 # This corresponds to FreeBSD's WARNS level 6

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,8 @@ if test "x$VARNISHTEST" = x; then
    AC_MSG_FAILURE([Can't locate varnishtest])
 fi
 
+PKG_CHECK_MODULES([OSSP], [ossp-uuid])
+
 # This corresponds to FreeBSD's WARNS level 6
 DEVELOPER_CFLAGS="-Wall -Wstrict-prototypes \
 -Wmissing-prototypes \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
-INCLUDES = -I$(VARNISHSRC)/include -I$(VARNISHSRC)
+AM_CPPFLAGS = @VMOD_INCLUDES@
 
-vmoddir = $(VMODDIR)
+vmoddir = @VMOD_DIR@
 vmod_LTLIBRARIES = libvmod_uuid.la
 
 libvmod_uuid_la_LDFLAGS = -module -export-dynamic -avoid-version -shared
@@ -9,15 +9,15 @@ libvmod_uuid_la_SOURCES = \
 	vcc_if.c \
 	vcc_if.h \
 	vmod_uuid.c
-
-vcc_if.c vcc_if.h: $(VARNISHSRC)/lib/libvmod_std/vmod.py $(top_srcdir)/src/vmod_uuid.vcc
-	@PYTHON@ $(VARNISHSRC)/lib/libvmod_std/vmod.py $(top_srcdir)/src/vmod_uuid.vcc
+	
+vcc_if.c vcc_if.h: @VMODTOOL@ $(top_srcdir)/src/vmod_uuid.vcc
+	@PYTHON@ @VMODTOOL@ $(top_srcdir)/src/vmod_uuid.vcc
 
 VMOD_TESTS = tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
 tests/*.vtc:
-	$(VARNISHSRC)/bin/varnishtest/varnishtest -Dvarnishd=$(VARNISHSRC)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
+	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,8 @@ AM_CPPFLAGS = @VMOD_INCLUDES@
 vmoddir = @VMOD_DIR@
 vmod_LTLIBRARIES = libvmod_uuid.la
 
-libvmod_uuid_la_LDFLAGS = -module -export-dynamic -avoid-version -shared
+libvmod_uuid_la_LDFLAGS = -module -export-dynamic -avoid-version -shared \
+	@OSSP_LIBS@
 
 libvmod_uuid_la_SOURCES = \
 	vcc_if.c \

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,0 +1,112 @@
+varnishtest "Test the various uuid versions"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+   import uuid from "${vmod_topbuild}/src/.libs/libvmod_uuid.so";
+
+   sub vcl_deliver {
+      if (uuid.uuid() ~
+          "^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$") {
+         set resp.http.uuid = "OK";
+      }
+
+      if (uuid.uuid_v1() ~
+          "^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v1 = "OK";
+      }
+
+      # Known v3 value from RFC 4122 Errata ID 1352      
+      if (uuid.uuid_v3("ns:DNS", "www.widgets.com") ==
+          "3d813cbb-47fb-32ba-91df-831e1593ac29") {
+         set resp.http.uuid_v3_dns_widgets = "OK";
+      }
+      if (uuid.uuid_v3("nil", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_nil_widgets = "OK";
+      }
+      if (uuid.uuid_v3("ns:URL", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_url_widgets = "OK";
+      }
+      if (uuid.uuid_v3("ns:OID", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_oid_widgets = "OK";
+      }
+      if (uuid.uuid_v3("ns:X500", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_x500_widgets = "OK";
+      }
+      if (uuid.uuid_v3("379b0b72-fcde-4276-96ff-94fe3066326a",
+                       "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v3_uuid_widgets = "OK";
+      }
+      if (uuid.uuid_v3("illegal", "www.widgets.com")) {
+         set resp.http.uuid_v3_illegal_ns = "NotOK";
+      }
+
+      if (uuid.uuid_v4() ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v4 = "OK";
+      }
+
+      # Known v5 value from ruby gem UUIDTools test data
+      if (uuid.uuid_v5("ns:DNS", "www.widgets.com") ==
+          "21f7f8de-8051-5b89-8680-0195ef798b6a") {
+         set resp.http.uuid_v5_dns_widgets = "OK";
+      }
+      if (uuid.uuid_v5("nil", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_nil_widgets = "OK";
+      }
+      if (uuid.uuid_v5("ns:URL", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_url_widgets = "OK";
+      }
+      if (uuid.uuid_v5("ns:OID", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_oid_widgets = "OK";
+      }
+      if (uuid.uuid_v5("ns:X500", "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_x500_widgets = "OK";
+      }
+      if (uuid.uuid_v5("379b0b72-fcde-4276-96ff-94fe3066326a",
+                       "www.widgets.com") ~
+      "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$") {
+         set resp.http.uuid_v5_uuid_widgets = "OK";
+      }
+      if (uuid.uuid_v5("illegal", "www.widgets.com")) {
+         set resp.http.uuid_v5_illegal_ns = "NotOK";
+      }
+   }
+} -start
+
+client c1 {
+   txreq -url "/"
+   rxresp
+   expect resp.http.uuid == "OK"
+   expect resp.http.uuid_v1 == "OK"
+   expect resp.http.uuid_v3_dns_widgets == "OK"
+   expect resp.http.uuid_v3_nil_widgets == "OK"
+   expect resp.http.uuid_v3_url_widgets == "OK"
+   expect resp.http.uuid_v3_oid_widgets == "OK"
+   expect resp.http.uuid_v3_x500_widgets == "OK"
+   expect resp.http.uuid_v3_uuid_widgets == "OK"
+   expect resp.http.uuid_v3_illegal_ns == <undef>
+   expect resp.http.uuid_v4 == "OK"
+   expect resp.http.uuid_v5_dns_widgets == "OK"
+   expect resp.http.uuid_v5_nil_widgets == "OK"
+   expect resp.http.uuid_v5_url_widgets == "OK"
+   expect resp.http.uuid_v5_oid_widgets == "OK"
+   expect resp.http.uuid_v5_x500_widgets == "OK"
+   expect resp.http.uuid_v5_uuid_widgets == "OK"
+   expect resp.http.uuid_v5_illegal_ns == <undef>
+}
+
+client c1 -run
+

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -104,8 +104,9 @@ _uuid(struct sess *sp, int utype, ...) {
    if (uuid_str == NULL)
       return(NULL);
 
+   assert(strlen(uuid_str) == UUID_LEN_STR);
    u = WS_Reserve(sp->wrk->ws, 0);     // Reserve some work space 
-   if (sizeof(uuid_str) > u) {
+   if (u < UUID_LEN_STR + 1) {
       // No space, reset and leave 
       WS_Release(sp->wrk->ws, 0);
       return(NULL);
@@ -114,15 +115,13 @@ _uuid(struct sess *sp, int utype, ...) {
    p = sp->wrk->ws->f;                 // Front of workspace area 
 
    strcpy(p, uuid_str);
-   // keep track of how much we actually used
-   v += strlen(uuid_str);
    // free up the uuid string once it's copied in place
    if(uuid_str){
       free(uuid_str);
    }
 
    // Update work space with what we've used 
-   WS_Release(sp->wrk->ws, v);
+   WS_Release(sp->wrk->ws, UUID_LEN_STR + 1);
    if (DEBUG)
       debug("uuid: %s", p);
    return(p);

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -22,28 +22,14 @@
 **
 */
 
-#include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 #include <uuid.h>
-
 #include <stdarg.h>
-#include <syslog.h>
 
 #include "vrt.h"
 #include "cache/cache.h"
 
 #include "vcc_if.h"
-
-#define DEBUG 0
-
-static void
-debug(const char *fmt, ...){
-   va_list ap;
-   va_start(ap, fmt);
-   vsyslog(LOG_DAEMON|LOG_INFO, fmt, ap);
-   va_end(ap);
-}
 
 #define UUID_CALL(RC,CTX,CALL,UUID,UUIDNS)                              \
    do {                                                                 \
@@ -88,8 +74,6 @@ mkuuid(const struct vrt_ctx *ctx, int utype, const char *str, va_list ap) {
     UUID_CALL(rc, ctx, uuid_destroy(uuid), uuid, uuid_ns);
     if (uuid_ns != NULL)
        uuid_destroy(uuid_ns);
-    if (DEBUG)
-       debug("uuid: %s", str);
     return(0);
 }
 

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -31,7 +31,7 @@
 #include <syslog.h>
 
 #include "vrt.h"
-#include "bin/varnishd/cache.h"
+#include "cache/cache.h"
 
 #include "vcc_if.h"
 
@@ -45,10 +45,10 @@ debug(const char *fmt, ...){
    va_end(ap);
 }
 
-#define UUID_CALL(RC,SP,CALL,UUID,UUIDNS)                               \
+#define UUID_CALL(RC,CTX,CALL,UUID,UUIDNS)                              \
    do {                                                                 \
      if (((RC) = (CALL)) != UUID_RC_OK) {                               \
-        WSP((SP), SLT_VCL_error, "vmod uuid error %d: %s", (RC),        \
+        VSLb((CTX)->vsl, SLT_VCL_Error, "vmod uuid error %d: %s", (RC), \
             uuid_error(RC));                                            \
         if ((UUID) != NULL)                                             \
            uuid_destroy(UUID);                                          \
@@ -59,14 +59,14 @@ debug(const char *fmt, ...){
    } while(0)
    
 static inline int
-mkuuid(struct sess *sp, int utype, const char *str, va_list ap) {
+mkuuid(const struct vrt_ctx *ctx, int utype, const char *str, va_list ap) {
     uuid_t *uuid = NULL, *uuid_ns = NULL;
     uuid_rc_t rc;
     char *ns, *name;
     size_t len = UUID_LEN_STR + 1;
 
     if (utype == UUID_MAKE_V3 || utype == UUID_MAKE_V5) {
-       UUID_CALL(rc, sp, uuid_create(&uuid_ns), uuid, uuid_ns);
+       UUID_CALL(rc, ctx, uuid_create(&uuid_ns), uuid, uuid_ns);
        ns = (char *) va_arg(ap, char *);
        AN(ns);
        name = (char *) va_arg(ap, char *);
@@ -74,18 +74,18 @@ mkuuid(struct sess *sp, int utype, const char *str, va_list ap) {
        if (uuid_load(uuid_ns, ns) != UUID_RC_OK
            && uuid_import(uuid_ns, UUID_FMT_STR, (const void *) ns, strlen(ns))
               != UUID_RC_OK) {
-          UUID_CALL(rc, sp, uuid_destroy(uuid_ns), uuid, uuid_ns);
+          UUID_CALL(rc, ctx, uuid_destroy(uuid_ns), uuid, uuid_ns);
           return(-1);
        }
        AN(uuid_ns);
     }
 
-    UUID_CALL(rc, sp, uuid_create(&uuid), uuid, uuid_ns);
-    UUID_CALL(rc, sp, uuid_make(uuid, utype, uuid_ns, name), uuid, uuid_ns);
-    UUID_CALL(rc, sp, uuid_export(uuid, UUID_FMT_STR, &str, &len), uuid,
+    UUID_CALL(rc, ctx, uuid_create(&uuid), uuid, uuid_ns);
+    UUID_CALL(rc, ctx, uuid_make(uuid, utype, uuid_ns, name), uuid, uuid_ns);
+    UUID_CALL(rc, ctx, uuid_export(uuid, UUID_FMT_STR, &str, &len), uuid,
               uuid_ns);
     assert(len == UUID_LEN_STR + 1);
-    UUID_CALL(rc, sp, uuid_destroy(uuid), uuid, uuid_ns);
+    UUID_CALL(rc, ctx, uuid_destroy(uuid), uuid, uuid_ns);
     if (uuid_ns != NULL)
        uuid_destroy(uuid_ns);
     if (DEBUG)
@@ -93,63 +93,52 @@ mkuuid(struct sess *sp, int utype, const char *str, va_list ap) {
     return(0);
 }
 
-static inline const char *
-_uuid(struct sess *sp, int utype, ...) {
+static VCL_STRING
+_uuid(const struct vrt_ctx *ctx, int utype, ...) {
    char *p, uuid_str[UUID_LEN_STR + 1];
-   unsigned u;
    va_list ap;
    int ret;
 
-   CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
+   CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
    assert(utype == UUID_MAKE_V1 || utype == UUID_MAKE_V3
           || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
 
    va_start(ap, utype);
-   ret = mkuuid(sp, utype, uuid_str, ap);
+   ret = mkuuid(ctx, utype, uuid_str, ap);
    va_end(ap);
    if (ret != 0)
       return(NULL);
 
    assert(strlen(uuid_str) == UUID_LEN_STR);
-   u = WS_Reserve(sp->wrk->ws, 0);     // Reserve some work space 
-   if (u < UUID_LEN_STR + 1) {
-      // No space, reset and leave
-      WSP(sp, SLT_VCL_error, "vmod uuid error: insufficient workspace");
-      WS_Release(sp->wrk->ws, 0);
-      return(NULL);
+   p = WS_Copy(ctx->ws, (const void *) uuid_str, UUID_LEN_STR + 1);
+   if (p == NULL) {
+           VSLb(ctx->vsl, SLT_VCL_Error, "vmod uuid: insufficient workspace");
+           return(NULL);
    }
-
-   p = sp->wrk->ws->f;                 // Front of workspace area 
-   strcpy(p, uuid_str);
-
-   // Update work space with what we've used 
-   WS_Release(sp->wrk->ws, UUID_LEN_STR + 1);
-   if (DEBUG)
-      debug("uuid: %s", p);
    return(p);
 }
 
-const char *
-vmod_uuid_v1(struct sess *sp) {
-   return _uuid(sp, UUID_MAKE_V1);
+VCL_STRING
+vmod_uuid_v1(const struct vrt_ctx *ctx) {
+   return _uuid(ctx, UUID_MAKE_V1);
 }
 
-const char *
-vmod_uuid_v3(struct sess *sp, const char *ns, const char *name) {
-   return _uuid(sp, UUID_MAKE_V3, ns, name);
+VCL_STRING
+vmod_uuid_v3(const struct vrt_ctx *ctx, VCL_STRING ns, VCL_STRING name) {
+   return _uuid(ctx, UUID_MAKE_V3, ns, name);
 }
 
-const char *
-vmod_uuid_v4(struct sess *sp) {
-   return _uuid(sp, UUID_MAKE_V4);
+VCL_STRING
+vmod_uuid_v4(const struct vrt_ctx *ctx) {
+   return _uuid(ctx, UUID_MAKE_V4);
 }
 
-const char *
-vmod_uuid_v5(struct sess *sp, const char *ns, const char *name) {
-   return _uuid(sp, UUID_MAKE_V5, ns, name);
+VCL_STRING
+vmod_uuid_v5(const struct vrt_ctx *ctx, VCL_STRING ns, VCL_STRING name) {
+   return _uuid(ctx, UUID_MAKE_V5, ns, name);
 }
 
-const char *
-vmod_uuid(struct sess *sp) {
-   return vmod_uuid_v1(sp);
+VCL_STRING
+vmod_uuid(const struct vrt_ctx *ctx) {
+   return vmod_uuid_v1(ctx);
 }

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -58,8 +58,8 @@ debug(const char *fmt, ...){
      }                                                                  \
    } while(0)
    
-static char *
-uuid(struct sess *sp, int utype, va_list ap) {
+static inline char *
+mkuuid(struct sess *sp, int utype, va_list ap) {
     uuid_t *uuid = NULL, *uuid_ns;
     uuid_rc_t rc;
     char *str = NULL, *ns, *name;
@@ -91,7 +91,7 @@ uuid(struct sess *sp, int utype, va_list ap) {
 static const char *
 _uuid(struct sess *sp, int utype, ...) {
    char *p;
-   unsigned u, v;
+   unsigned u;
    va_list ap;
 
    CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
@@ -99,7 +99,7 @@ _uuid(struct sess *sp, int utype, ...) {
           || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
 
    va_start(ap, utype);
-   char *uuid_str = uuid(sp, utype, ap);
+   char *uuid_str = mkuuid(sp, utype, ap);
    va_end(ap);
    if (uuid_str == NULL)
       return(NULL);

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -13,13 +13,17 @@
 **   See the License for the specific language governing permissions and
 **   limitations under the License.
 **
-**
+** Original Varnish 3 version:
 ** vmod_uuid.c  Generate a UUID for use by varnish
 ** Date:        08/23/2013
 ** By:          Mitchell Broome <mbroome@sharecare.com>
 ** Version:     0.1
 **
 **
+** Varnish 4 version, supporting all UUID variants:
+** Geoffrey Simmons <geoff@uplex.de>, UPLEX Nils Goroll Systemoptimierung
+** for Otto GmbH & KG
+** Version 1.0
 */
 
 #include <string.h>

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -31,98 +31,109 @@
 
 #include "vcc_if.h"
 
-#define UUID_CALL(RC,CTX,CALL,UUID,UUIDNS)                              \
-   do {                                                                 \
-     if (((RC) = (CALL)) != UUID_RC_OK) {                               \
-        VSLb((CTX)->vsl, SLT_VCL_Error, "vmod uuid error %d: %s", (RC), \
-            uuid_error(RC));                                            \
-        if ((UUID) != NULL)                                             \
-           uuid_destroy(UUID);                                          \
-        if ((UUIDNS) != NULL)                                           \
-           uuid_destroy(UUIDNS);                                        \
-        return(-1);                                                     \
-     }                                                                  \
-   } while(0)
+#define UUID_CALL(RC,CTX,CALL,UUID,UUIDNS)			\
+	do {							\
+		if (((RC) = (CALL)) != UUID_RC_OK) {		\
+			VSLb((CTX)->vsl, SLT_VCL_Error,		\
+			    "vmod uuid error %d: %s", (RC),	\
+			    uuid_error(RC));			\
+			if ((UUID) != NULL)			\
+				uuid_destroy(UUID);		\
+			if ((UUIDNS) != NULL)			\
+				uuid_destroy(UUIDNS);		\
+			return(-1);				\
+		}						\
+	} while(0)
    
 static inline int
-mkuuid(const struct vrt_ctx *ctx, int utype, const char *str, va_list ap) {
-    uuid_t *uuid = NULL, *uuid_ns = NULL;
-    uuid_rc_t rc;
-    char *ns, *name;
-    size_t len = UUID_LEN_STR + 1;
+mkuuid(const struct vrt_ctx *ctx, int utype, const char *str, va_list ap)
+{
+	uuid_t *uuid = NULL, *uuid_ns = NULL;
+	uuid_rc_t rc;
+	char *ns, *name;
+	size_t len = UUID_LEN_STR + 1;
 
-    if (utype == UUID_MAKE_V3 || utype == UUID_MAKE_V5) {
-       UUID_CALL(rc, ctx, uuid_create(&uuid_ns), uuid, uuid_ns);
-       ns = (char *) va_arg(ap, char *);
-       AN(ns);
-       name = (char *) va_arg(ap, char *);
-       AN(name);
-       if (uuid_load(uuid_ns, ns) != UUID_RC_OK
-           && uuid_import(uuid_ns, UUID_FMT_STR, (const void *) ns, strlen(ns))
-              != UUID_RC_OK) {
-          UUID_CALL(rc, ctx, uuid_destroy(uuid_ns), uuid, uuid_ns);
-          return(-1);
-       }
-       AN(uuid_ns);
-    }
+	if (utype == UUID_MAKE_V3 || utype == UUID_MAKE_V5) {
+		UUID_CALL(rc, ctx, uuid_create(&uuid_ns), uuid, uuid_ns);
+		ns = (char *) va_arg(ap, char *);
+		AN(ns);
+		name = (char *) va_arg(ap, char *);
+		AN(name);
+		if (uuid_load(uuid_ns, ns) != UUID_RC_OK
+		    && uuid_import(uuid_ns, UUID_FMT_STR, (const void *) ns,
+                                   strlen(ns)) != UUID_RC_OK) {
+			UUID_CALL(rc, ctx, uuid_destroy(uuid_ns), uuid,
+                                  uuid_ns);
+			return(-1);
+		}
+		AN(uuid_ns);
+	}
 
-    UUID_CALL(rc, ctx, uuid_create(&uuid), uuid, uuid_ns);
-    UUID_CALL(rc, ctx, uuid_make(uuid, utype, uuid_ns, name), uuid, uuid_ns);
-    UUID_CALL(rc, ctx, uuid_export(uuid, UUID_FMT_STR, &str, &len), uuid,
-              uuid_ns);
-    assert(len == UUID_LEN_STR + 1);
-    UUID_CALL(rc, ctx, uuid_destroy(uuid), uuid, uuid_ns);
-    if (uuid_ns != NULL)
-       uuid_destroy(uuid_ns);
-    return(0);
+	UUID_CALL(rc, ctx, uuid_create(&uuid), uuid, uuid_ns);
+	UUID_CALL(rc, ctx, uuid_make(uuid, utype, uuid_ns, name), uuid,
+                  uuid_ns);
+	UUID_CALL(rc, ctx, uuid_export(uuid, UUID_FMT_STR, &str, &len), uuid,
+	          uuid_ns);
+	assert(len == UUID_LEN_STR + 1);
+	UUID_CALL(rc, ctx, uuid_destroy(uuid), uuid, uuid_ns);
+	if (uuid_ns != NULL)
+		uuid_destroy(uuid_ns);
+	return(0);
 }
 
 static VCL_STRING
-_uuid(const struct vrt_ctx *ctx, int utype, ...) {
-   char *p, uuid_str[UUID_LEN_STR + 1];
-   va_list ap;
-   int ret;
+_uuid(const struct vrt_ctx *ctx, int utype, ...)
+{
+	char *p, uuid_str[UUID_LEN_STR + 1];
+	va_list ap;
+	int ret;
 
-   CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-   assert(utype == UUID_MAKE_V1 || utype == UUID_MAKE_V3
-          || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	assert(utype == UUID_MAKE_V1 || utype == UUID_MAKE_V3
+	    || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
 
-   va_start(ap, utype);
-   ret = mkuuid(ctx, utype, uuid_str, ap);
-   va_end(ap);
-   if (ret != 0)
-      return(NULL);
+	va_start(ap, utype);
+	ret = mkuuid(ctx, utype, uuid_str, ap);
+	va_end(ap);
+	if (ret != 0)
+		return(NULL);
 
-   assert(strlen(uuid_str) == UUID_LEN_STR);
-   p = WS_Copy(ctx->ws, (const void *) uuid_str, UUID_LEN_STR + 1);
-   if (p == NULL) {
-           VSLb(ctx->vsl, SLT_VCL_Error, "vmod uuid: insufficient workspace");
-           return(NULL);
-   }
-   return(p);
+	assert(strlen(uuid_str) == UUID_LEN_STR);
+	p = WS_Copy(ctx->ws, (const void *) uuid_str, UUID_LEN_STR + 1);
+	if (p == NULL) {
+		VSLb(ctx->vsl, SLT_VCL_Error,
+                    "vmod uuid: insufficient workspace");
+		return(NULL);
+	}
+	return(p);
 }
 
 VCL_STRING
-vmod_uuid_v1(const struct vrt_ctx *ctx) {
-   return _uuid(ctx, UUID_MAKE_V1);
+vmod_uuid_v1(const struct vrt_ctx *ctx)
+{
+	return _uuid(ctx, UUID_MAKE_V1);
 }
 
 VCL_STRING
-vmod_uuid_v3(const struct vrt_ctx *ctx, VCL_STRING ns, VCL_STRING name) {
-   return _uuid(ctx, UUID_MAKE_V3, ns, name);
+vmod_uuid_v3(const struct vrt_ctx *ctx, VCL_STRING ns, VCL_STRING name)
+{
+	return _uuid(ctx, UUID_MAKE_V3, ns, name);
 }
 
 VCL_STRING
-vmod_uuid_v4(const struct vrt_ctx *ctx) {
-   return _uuid(ctx, UUID_MAKE_V4);
+vmod_uuid_v4(const struct vrt_ctx *ctx)
+{
+	return _uuid(ctx, UUID_MAKE_V4);
 }
 
 VCL_STRING
-vmod_uuid_v5(const struct vrt_ctx *ctx, VCL_STRING ns, VCL_STRING name) {
-   return _uuid(ctx, UUID_MAKE_V5, ns, name);
+vmod_uuid_v5(const struct vrt_ctx *ctx, VCL_STRING ns, VCL_STRING name)
+{
+	return _uuid(ctx, UUID_MAKE_V5, ns, name);
 }
 
 VCL_STRING
-vmod_uuid(const struct vrt_ctx *ctx) {
-   return vmod_uuid_v1(ctx);
+vmod_uuid(const struct vrt_ctx *ctx)
+{
+	return vmod_uuid_v1(ctx);
 }

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -45,27 +45,28 @@ debug(const char *fmt, ...){
    va_end(ap);
 }
 
-#define UUID_CALL(RC,SP,CALL,UUID,STR)                                  \
+#define UUID_CALL(RC,SP,CALL,UUID,UUIDNS)                               \
    do {                                                                 \
      if (((RC) = (CALL)) != UUID_RC_OK) {                               \
         WSP((SP), SLT_VCL_error, "vmod uuid error %d: %s", (RC),        \
             uuid_error(RC));                                            \
         if ((UUID) != NULL)                                             \
            uuid_destroy(UUID);                                          \
-        if ((STR) != NULL)                                              \
-           free(STR);                                                   \
-        return(NULL);                                                   \
+        if ((UUIDNS) != NULL)                                           \
+           uuid_destroy(UUIDNS);                                        \
+        return(-1);                                                     \
      }                                                                  \
    } while(0)
    
-static inline char *
-mkuuid(struct sess *sp, int utype, va_list ap) {
-    uuid_t *uuid = NULL, *uuid_ns;
+static inline int
+mkuuid(struct sess *sp, int utype, const char *str, va_list ap) {
+    uuid_t *uuid = NULL, *uuid_ns = NULL;
     uuid_rc_t rc;
-    char *str = NULL, *ns, *name;
+    char *ns, *name;
+    size_t len = UUID_LEN_STR + 1;
 
     if (utype == UUID_MAKE_V3 || utype == UUID_MAKE_V5) {
-       UUID_CALL(rc, sp, uuid_create(&uuid_ns), uuid, str);
+       UUID_CALL(rc, sp, uuid_create(&uuid_ns), uuid, uuid_ns);
        ns = (char *) va_arg(ap, char *);
        AN(ns);
        name = (char *) va_arg(ap, char *);
@@ -73,52 +74,53 @@ mkuuid(struct sess *sp, int utype, va_list ap) {
        if (uuid_load(uuid_ns, ns) != UUID_RC_OK
            && uuid_import(uuid_ns, UUID_FMT_STR, (const void *) ns, strlen(ns))
               != UUID_RC_OK) {
-          UUID_CALL(rc, sp, uuid_destroy(uuid_ns), uuid, str);
-          return(NULL);
+          UUID_CALL(rc, sp, uuid_destroy(uuid_ns), uuid, uuid_ns);
+          return(-1);
        }
+       AN(uuid_ns);
     }
 
-    UUID_CALL(rc, sp, uuid_create(&uuid), uuid, str);
-    UUID_CALL(rc, sp, uuid_make(uuid, utype, uuid_ns, name), uuid, str);
-    str = NULL;
-    UUID_CALL(rc, sp, uuid_export(uuid, UUID_FMT_STR, &str, NULL), uuid, str);
-    UUID_CALL(rc, sp, uuid_destroy(uuid), uuid, str);
+    UUID_CALL(rc, sp, uuid_create(&uuid), uuid, uuid_ns);
+    UUID_CALL(rc, sp, uuid_make(uuid, utype, uuid_ns, name), uuid, uuid_ns);
+    UUID_CALL(rc, sp, uuid_export(uuid, UUID_FMT_STR, &str, &len), uuid,
+              uuid_ns);
+    assert(len == UUID_LEN_STR + 1);
+    UUID_CALL(rc, sp, uuid_destroy(uuid), uuid, uuid_ns);
+    if (uuid_ns != NULL)
+       uuid_destroy(uuid_ns);
     if (DEBUG)
        debug("uuid: %s", str);
-    return(str);
+    return(0);
 }
 
-static const char *
+static inline const char *
 _uuid(struct sess *sp, int utype, ...) {
-   char *p;
+   char *p, uuid_str[UUID_LEN_STR + 1];
    unsigned u;
    va_list ap;
+   int ret;
 
    CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
    assert(utype == UUID_MAKE_V1 || utype == UUID_MAKE_V3
           || utype == UUID_MAKE_V4 || utype == UUID_MAKE_V5);
 
    va_start(ap, utype);
-   char *uuid_str = mkuuid(sp, utype, ap);
+   ret = mkuuid(sp, utype, uuid_str, ap);
    va_end(ap);
-   if (uuid_str == NULL)
+   if (ret != 0)
       return(NULL);
 
    assert(strlen(uuid_str) == UUID_LEN_STR);
    u = WS_Reserve(sp->wrk->ws, 0);     // Reserve some work space 
    if (u < UUID_LEN_STR + 1) {
-      // No space, reset and leave 
+      // No space, reset and leave
+      WSP(sp, SLT_VCL_error, "vmod uuid error: insufficient workspace");
       WS_Release(sp->wrk->ws, 0);
       return(NULL);
    }
 
    p = sp->wrk->ws->f;                 // Front of workspace area 
-
    strcpy(p, uuid_str);
-   // free up the uuid string once it's copied in place
-   if(uuid_str){
-      free(uuid_str);
-   }
 
    // Update work space with what we've used 
    WS_Release(sp->wrk->ws, UUID_LEN_STR + 1);

--- a/src/vmod_uuid.vcc
+++ b/src/vmod_uuid.vcc
@@ -1,2 +1,6 @@
 Module uuid
-Function STRING uuid(PRIV_CALL)
+Function STRING uuid()
+Function STRING uuid_v1()
+Function STRING uuid_v3(STRING, STRING)
+Function STRING uuid_v4()
+Function STRING uuid_v5(STRING, STRING)

--- a/src/vmod_uuid.vcc
+++ b/src/vmod_uuid.vcc
@@ -1,6 +1,6 @@
-Module uuid
-Function STRING uuid()
-Function STRING uuid_v1()
-Function STRING uuid_v3(STRING, STRING)
-Function STRING uuid_v4()
-Function STRING uuid_v5(STRING, STRING)
+$Module uuid 3 UUID
+$Function STRING uuid()
+$Function STRING uuid_v1()
+$Function STRING uuid_v3(STRING, STRING)
+$Function STRING uuid_v4()
+$Function STRING uuid_v5(STRING, STRING)

--- a/vmod-uuid.spec
+++ b/vmod-uuid.spec
@@ -6,7 +6,7 @@ License: BSD
 Group: System Environment/Daemons
 Source0: libvmod-uuid.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires: varnish > 3.0
+Requires: varnish > 4.0
 BuildRequires: make, python-docutils
 
 %description
@@ -16,9 +16,7 @@ UUID VMOD
 %setup -n libvmod-uuid
 
 %build
-# this assumes that VARNISHSRC is defined on the rpmbuild command line, like this:
-# rpmbuild -bb --define 'VARNISHSRC /home/user/rpmbuild/BUILD/varnish-3.0.3' redhat/*spec
-./configure VARNISHSRC=%{VARNISHSRC} VMODDIR="$(PKG_CONFIG_PATH=%{VARNISHSRC} pkg-config --variable=vmoddir varnishapi)" --prefix=/usr/
+./configure --prefix=/usr/ --docdir='${datarootdir}/doc/%{name}'
 make
 make check
 


### PR DESCRIPTION
This includes all of the previous PR (support for all of the UUID variants supported by OSSP), and updates the VMOD for Varnish 4.